### PR TITLE
fix: support query string / search params

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ class FastifyUndiciDispatcher extends Dispatcher {
 
     server.inject({
       method: opts.method,
-      url: url.pathname,
+      url: url.pathname + url.search,
       headers: opts.headers,
       body: opts.body
     }).then(res => {

--- a/test.js
+++ b/test.js
@@ -51,6 +51,27 @@ test('pass-through', async (t) => {
   assert.strictEqual(text, 'hello world 2')
 })
 
+test('pass-through query string', async (t) => {
+  const server = Fastify()
+  server.get('/query', async (req, reply) => {
+    return req.query.test
+  })
+  await server.listen({ port: 0 })
+
+  const dispatcher = new FastifyUndiciDispatcher({
+    dispatcher: new Agent()
+  })
+  t.after(() => dispatcher.close())
+  t.after(() => server.close())
+
+  const res = await request(`http://127.0.0.1:${server.addresses()[0].port}/query?test=test`, {
+    dispatcher
+  })
+
+  const text = await res.body.text()
+  assert.strictEqual(text, 'test', 'query string not passed through')
+})
+
 test('no server found', async (t) => {
   const dispatcher = new FastifyUndiciDispatcher()
 


### PR DESCRIPTION
When using Platformatic Runtime, I noticed the Query params were not being passed through to a service.

This change allows the pass through of searchParams from the parsed url.

