### PR TITLE
Route via socket if target server is listening to a port

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An undici dispatcher to in-process Fastify servers",
   "main": "index.js",
   "scripts": {
-    "test": "standard | snazzy && c8 --100 node test.js"
+    "test": "standard | snazzy && c8 --100 node --test test/*.test.js"
   },
   "repository": {
     "type": "git",
@@ -18,11 +18,12 @@
   },
   "homepage": "https://github.com/mcollina/fastify-undici-dispatcher#readme",
   "devDependencies": {
+    "@fastify/express": "^2.3.0",
     "c8": "^8.0.0",
+    "express": "^4.18.2",
     "fastify": "^4.15.0",
     "snazzy": "^9.0.0",
-    "standard": "^17.0.0",
-    "test": "^3.3.0"
+    "standard": "^17.0.0"
   },
   "dependencies": {
     "undici": "^5.21.2"

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const test = require('test')
+const test = require('node:test')
 const assert = require('assert')
 const { request, Agent } = require('undici')
-const FastifyUndiciDispatcher = require('.')
+const FastifyUndiciDispatcher = require('..')
 const Fastify = require('fastify')
 
 test('basic usage', async (t) => {

--- a/test/listening.test.js
+++ b/test/listening.test.js
@@ -1,0 +1,71 @@
+'use strict'
+
+const test = require('node:test')
+const assert = require('assert')
+const { request, Agent } = require('undici')
+const FastifyUndiciDispatcher = require('..')
+const Fastify = require('fastify')
+const FastifyExpress = require('@fastify/express')
+const { Router } = require('express')
+
+test('listening server', async (t) => {
+  const server = Fastify()
+  server.get('/', async (req, reply) => {
+    return 'root'
+  })
+  server.get('/foo', async (req, reply) => {
+    assert.notStrictEqual(req.headers['user-agent'], 'lightMyRequest')
+    return 'foo'
+  })
+  await server.listen({ port: 0 })
+  t.after(() => server.close())
+
+  const dispatcher = new FastifyUndiciDispatcher({
+    dispatcher: new Agent()
+  })
+  dispatcher.route('myserver.local', server)
+
+  {
+    const res = await request('http://myserver.local/', { dispatcher })
+    assert.strictEqual(await res.body.text(), 'root')
+  }
+
+  {
+    const res = await request('http://myserver.local/foo', { dispatcher })
+    assert.strictEqual(await res.body.text(), 'foo')
+  }
+})
+
+test('supports @fastify/express', async (t) => {
+  const server = Fastify()
+
+  const router = Router()
+
+  router.get('/', (req, res) => {
+    res.send('root')
+  })
+  router.get('/foo', (req, res) => {
+    res.send('foo')
+  })
+
+  await server.register(FastifyExpress)
+  server.use(router)
+
+  await server.listen({ port: 0 })
+  t.after(() => server.close())
+
+  const dispatcher = new FastifyUndiciDispatcher({
+    dispatcher: new Agent()
+  })
+  dispatcher.route('myserver.local', server)
+
+  {
+    const res = await request('http://myserver.local/', { dispatcher })
+    assert.strictEqual(await res.body.text(), 'root')
+  }
+
+  {
+    const res = await request('http://myserver.local/foo', { dispatcher })
+    assert.strictEqual(await res.body.text(), 'foo')
+  }
+})


### PR DESCRIPTION
This PR also moves the test framework to `node:test` and drop Node.js v16.