### PR TITLE
fix readme interceptor example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An undici dispatcher to in-process Fastify servers
 npm i fastify fastify-undici-dispatcher undici
 ```
 
-## Usage as a Interceptor
+## Usage as an Interceptor
 
 ```js
 const { request, Agent } = require('undici')

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ const interceptor = createFastifyInterceptor({
   domain: '.local' // optional
 })
 
-const dispatcher = new Agent.compose(interceptor)
+const dispatcher = new Agent().compose(interceptor)
 dispatcher.route('myserver', server)
 
 request('http://myserver.local', {


### PR DESCRIPTION
Randomly decided to watch one of your previous streams and saw that the `Agent` class wasn't properly initialized in the example ¯\\\_(ツ)\_/¯